### PR TITLE
fix(abacus): use --config flag for phonopy 4.1.0 load mode compatibility

### DIFF
--- a/apex/core/property/Gruneisen.py
+++ b/apex/core/property/Gruneisen.py
@@ -963,7 +963,7 @@ if __name__ == "__main__":
                 if not os.path.isfile("FORCE_CONSTANTS"):
                     raise FileNotFoundError(f"FORCE_CONSTANTS was not created in {helper_dir}")
                 if not os.path.isfile("mesh.yaml"):
-                    subprocess.check_call(Phonon.phonopy_command("band.conf"), shell=True)
+                    subprocess.check_call(Phonon.phonopy_command("phonopy_disp.yaml --config band.conf"), shell=True)
                     self._write_band_dat()
             finally:
                 os.chdir(cwd)

--- a/apex/core/property/Phonon.py
+++ b/apex/core/property/Phonon.py
@@ -622,7 +622,7 @@ class Phonon(Property):
                     if not os.path.exists("FORCE_SETS"):
                         raise FileNotFoundError("FORCE_SETS was not created")
                     print('FORCE_SETS is created')
-                    subprocess.check_call(self.phonopy_command("band.conf"), shell=True)
+                    subprocess.check_call(self.phonopy_command("phonopy_disp.yaml --config band.conf"), shell=True)
                     self.write_band_dat()
 
                 elif self.inter_param["type"] == 'vasp':

--- a/tests/test_gruneisen.py
+++ b/tests/test_gruneisen.py
@@ -408,7 +408,7 @@ class TestGruneisen(unittest.TestCase):
                 Path("FORCE_SETS").write_text("fake force sets\n")
             elif command == Phonon.phonopy_setup_command("phonopy_disp.yaml --writefc"):
                 Path("FORCE_CONSTANTS").write_text("fake force constants\n")
-            elif command == Phonon.phonopy_command("band.conf"):
+            elif command == Phonon.phonopy_command("phonopy_disp.yaml --config band.conf"):
                 strain = loadfn("volume.json")["strain"]
                 if strain < 0:
                     frequencies = [4.2, 8.4]
@@ -459,8 +459,11 @@ class TestGruneisen(unittest.TestCase):
             ]),
             3,
         )
-        self.assertEqual(len([cmd for _, cmd in calls if cmd == Phonon.phonopy_command("band.conf")]), 3)
-        self.assertFalse(any(cmd == "phonopy band.conf --abacus" for _, cmd in calls))
+        self.assertEqual(
+            len([cmd for _, cmd in calls if cmd == Phonon.phonopy_command("phonopy_disp.yaml --config band.conf")]),
+            3,
+        )
+        self.assertFalse(any(cmd == "phonopy phonopy_disp.yaml --config band.conf --abacus" for _, cmd in calls))
         self.assertTrue((work_dir / "volume.000000" / "mesh.yaml").is_file())
         self.assertTrue((work_dir / "volume.000001" / "band.dat").is_file())
         self.assertTrue("Temperature(K)  SumGammaCv  Sign" in ptr)

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -340,7 +340,7 @@ class TestPhonon(unittest.TestCase):
             calls.append(command)
             if command.startswith(Phonon.phonopy_setup_command("-f")):
                 Path("FORCE_SETS").write_text("fake force sets\n")
-            elif command == Phonon.phonopy_command("band.conf"):
+            elif command == Phonon.phonopy_command("phonopy_disp.yaml --config band.conf"):
                 Path("band.yaml").write_text("phonon: []\n")
 
         try:
@@ -349,8 +349,8 @@ class TestPhonon(unittest.TestCase):
                     patch.object(Phonon, "write_band_dat", side_effect=self._write_band_dat_for_compute):
                 phonon._compute_lower(str(work_dir / "result.json"), [str(task_dir)], [])
             self.assertEqual(calls[0], Phonon.phonopy_setup_command("-f task.0*/OUT.ABACUS/running_scf.log"))
-            self.assertEqual(calls[1], Phonon.phonopy_command("band.conf"))
-            self.assertFalse(any("--abacus" in command and command.startswith("phonopy band.conf") for command in calls))
+            self.assertEqual(calls[1], Phonon.phonopy_command("phonopy_disp.yaml --config band.conf"))
+            self.assertFalse(any("--abacus" in command and "band.conf" in command for command in calls))
         finally:
             shutil.rmtree(work_dir, ignore_errors=True)
 


### PR DESCRIPTION
phonopy 4.1.0 ignores positional conf file arguments when in 'load mode' (triggered by phonopy_disp.yaml). This caused band.yaml/mesh.yaml to not be generated during the Post step for ABACUS phonon and gruneisen properties.

Fix: pass band.conf explicitly via --config flag, which phonopy 4.1.0 correctly reads as a configuration file even in load mode.

Tested with Cu FCC (ABACUS DFT, 2x2x2 supercell):
- phonon: band.yaml + band.dat + mesh.yaml generated successfully
- gruneisen: FORCE_CONSTANTS + mesh.yaml (3 volumes) generated successfully